### PR TITLE
#124 TwitchのDisplayNameに対応

### DIFF
--- a/TwitchSitePlugin/CommentProvider.cs
+++ b/TwitchSitePlugin/CommentProvider.cs
@@ -272,17 +272,25 @@ namespace TwitchSitePlugin
         {
             var commentData = ParsePrivMsg(result);
             var userId = commentData.UserId;
+            var displayName = commentData.DisplayName;
             var isFirstComment = _commentCounter.UpdateCount(userId);
             var user = GetUser(userId);
             if (_siteOptions.NeedAutoSubNickname)
             {
                 SitePluginCommon.Utils.SetNickname(commentData.Message, user);
             }
+            if (commentData.Username.Equals(displayName))
+            {
+                displayName = "";
+            } else
+            {
+                displayName = " (" + displayName + ")";
+            }
             var message = new TwitchComment(result.Raw)
             {
                 CommentItems = Tools.GetMessageItems(result),
                 Id = commentData.Id,
-                NameItems = new List<IMessagePart> { MessagePartFactory.CreateMessageText(commentData.Username) },
+                NameItems = new List<IMessagePart> { MessagePartFactory.CreateMessageText(commentData.Username), MessagePartFactory.CreateMessageText(displayName) },
                 PostTime = commentData.SentAt.ToString("HH:mm:ss"),
                 UserId = commentData.UserId,
             };
@@ -444,6 +452,7 @@ namespace TwitchSitePlugin
     {
         public string UserId { get; set; }
         public string Username { get; set; }
+        public string DisplayName { get; set; }
         public string Message { get; set; }
         public string Emotes { get; set; }
         public string Id { get; set; }

--- a/TwitchSitePlugin/CommentProvider.cs
+++ b/TwitchSitePlugin/CommentProvider.cs
@@ -281,16 +281,16 @@ namespace TwitchSitePlugin
             }
             if (commentData.Username.Equals(displayName))
             {
-                displayName = "";
+                displayName = userId;
             } else
             {
-                displayName = " (" + displayName + ")";
+                displayName = displayName + " (" + userId + ")";
             }
             var message = new TwitchComment(result.Raw)
             {
                 CommentItems = Tools.GetMessageItems(result),
                 Id = commentData.Id,
-                NameItems = new List<IMessagePart> { MessagePartFactory.CreateMessageText(commentData.Username), MessagePartFactory.CreateMessageText(displayName) },
+                NameItems = new List<IMessagePart> { MessagePartFactory.CreateMessageText(displayName) },
                 PostTime = commentData.SentAt.ToString("HH:mm:ss"),
                 UserId = commentData.UserId,
             };

--- a/TwitchSitePlugin/ICommentData.cs
+++ b/TwitchSitePlugin/ICommentData.cs
@@ -7,6 +7,7 @@
         string Message { get; }
         string UserId { get; }
         string Username { get; }
+        string DisplayName { get; }
         System.DateTime SentAt { get; }
     }
 }

--- a/TwitchSitePlugin/Tools.cs
+++ b/TwitchSitePlugin/Tools.cs
@@ -39,6 +39,10 @@ namespace TwitchSitePlugin
             {
                 commentData.UserId = userId;
             }
+            if (result.Tags.TryGetValue("display-name", out string displayName))
+            {
+                commentData.DisplayName = displayName;
+            }
             if(result.Tags.TryGetValue("tmi-sent-ts", out string ts))
             {
                 var unix = new DateTime(1970, 1, 1).AddMilliseconds(long.Parse(ts));

--- a/TwitchSitePlugin/TwitchCommentViewModel.cs
+++ b/TwitchSitePlugin/TwitchCommentViewModel.cs
@@ -8,6 +8,7 @@ namespace TwitchSitePlugin
     {
         public override MessageType MessageType { get; protected set; }
         public override string UserId { get; }
+        public string DisplayName { get; }
         private readonly ITwitchSiteOptions _siteOptions;
         public TwitchCommentViewModel(ICommentOptions options, ITwitchSiteOptions siteOptions,
             ICommentData commentData, bool isFirstComment, ICommentProvider commentProvider, IUser user)
@@ -17,6 +18,7 @@ namespace TwitchSitePlugin
             _siteOptions = siteOptions;
             Id = commentData.Id;
             UserId = commentData.UserId;
+            DisplayName = commentData.DisplayName;
             PostTime = commentData.SentAt.ToString("HH:mm:ss");
 
             var name = commentData.Username;


### PR DESCRIPTION
暫定的に対応してみました。
DisplayNameがUserIdと同じ場合は表示しません。
本当は別カラムに表示したいですが取り急ぎ…。

![EB38HRgAcy](https://user-images.githubusercontent.com/1085968/67449386-f505e200-f654-11e9-80aa-1d22c604b394.png)