### PR TITLE
棒読みちゃんプラグインに、読み上げ音声を指定できるように、設定項目を追加

### DIFF
--- a/BouyomiPlugin/ConfigView.xaml
+++ b/BouyomiPlugin/ConfigView.xaml
@@ -21,7 +21,39 @@
                     <TextBox x:Name="textBox1" IsEnabled="{Binding IsChecked, ElementName=checkBox1}" HorizontalAlignment="Left" Height="23" Margin="215,45,0,0" TextWrapping="Wrap" Text="{Binding NickTitle}" VerticalAlignment="Top" Width="120"/>
                     <CheckBox Content="184コメントも読ませる" IsChecked="{Binding Want184Read}" HorizontalAlignment="Left" Margin="182,87,0,0" VerticalAlignment="Top"/>
                     <CheckBox Content="コメビュ終了時に棒読みちゃんも終了させる（自動起動した場合のみ）" IsChecked="{Binding IsKillBouyomiChan}" HorizontalAlignment="Left" Margin="10,175,0,0" VerticalAlignment="Top"/>
-
+                    <CheckBox x:Name="voiceTypeSpecifiedCheckBox" Content="読み上げ音声を指定する" IsChecked="{Binding IsVoiceTypeSpecfied}" HorizontalAlignment="Left" Margin="10,204,0,0" VerticalAlignment="Top"/>
+                    <Grid IsEnabled="{Binding IsChecked, ElementName=voiceTypeSpecifiedCheckBox}" Margin="15,224,10,10">
+                        <Label Content="声質" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top"/>
+                        <ComboBox SelectedIndex="{Binding VoiceTypeSelectedIndex}" HorizontalAlignment="Left" Margin="49,12,0,0" VerticalAlignment="Top" Width="120">
+                            <ComboBoxItem Content="デフォルト"/>
+                            <ComboBoxItem Content="女性１"/>
+                            <ComboBoxItem Content="女性２"/>
+                            <ComboBoxItem Content="男性１"/>
+                            <ComboBoxItem Content="男性２"/>
+                            <ComboBoxItem Content="中性"/>
+                            <ComboBoxItem Content="ロボット"/>
+                            <ComboBoxItem Content="機械１"/>
+                            <ComboBoxItem Content="機械２"/>
+                            <ComboBoxItem Content="SAPI5#1"/>
+                            <ComboBoxItem Content="SAPI5#2"/>
+                            <ComboBoxItem Content="SAPI5#3"/>
+                            <ComboBoxItem Content="SAPI5#4"/>
+                            <ComboBoxItem Content="SAPI5#5"/>
+                            <ComboBoxItem Content="SAPI5#6"/>
+                            <ComboBoxItem Content="SAPI5#7"/>
+                            <ComboBoxItem Content="SAPI5#8"/>
+                            <ComboBoxItem Content="SAPI5#9"/>
+                        </ComboBox>
+                        <Label Content="音量" HorizontalAlignment="Left" Margin="10,35,0,0" VerticalAlignment="Top"/>
+                        <Slider x:Name="voiceVolumeSlider" Minimum="-1" Maximum="100" Value="{Binding VoiceVolume}" TickFrequency="1" IsSnapToTickEnabled="True" HorizontalAlignment="Left" Margin="49,39,0,0" VerticalAlignment="Top" Width="120"/>
+                        <TextBlock Text="{Binding Value, ElementName=voiceVolumeSlider}" HorizontalAlignment="Left" Margin="174,40,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Width="40"/>
+                        <Label Content="速度" HorizontalAlignment="Left" Margin="10,61,0,0" VerticalAlignment="Top"/>
+                        <Slider x:Name="voiceSpeedSlider" Minimum="50" Maximum="300" Value="{Binding VoiceSpeed}" TickFrequency="1" IsSnapToTickEnabled="True" HorizontalAlignment="Left" Margin="49,65,0,0" VerticalAlignment="Top" Width="120"/>
+                        <TextBlock Text="{Binding Value, ElementName=voiceSpeedSlider}" HorizontalAlignment="Left" Margin="174,66,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Width="40"/>
+                        <Label Content="音程" HorizontalAlignment="Left" Margin="10,87,0,0" VerticalAlignment="Top"/>
+                        <Slider x:Name="voiceToneSlider" Minimum="50" Maximum="200" Value="{Binding VoiceTone}" TickFrequency="1" IsSnapToTickEnabled="True" HorizontalAlignment="Left" Margin="49,91,0,0" VerticalAlignment="Top" Width="120"/>
+                        <TextBlock Text="{Binding Value, ElementName=voiceToneSlider}" HorizontalAlignment="Left" Margin="174,92,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Width="40"/>
+                    </Grid>
                 </Grid>
             </TabItem>
             <TabItem Header="読んでもらうメッセージ">

--- a/BouyomiPlugin/ConfigViewModel.cs
+++ b/BouyomiPlugin/ConfigViewModel.cs
@@ -7,6 +7,9 @@ namespace BouyomiPlugin
 {
     class ConfigViewModel : ViewModelBase
     {
+        private const int VoiceTypeSapi5Offset = 10001;
+        private readonly int VoiceTypeLength = Enum.GetNames(typeof(FNF.Utility.VoiceType)).Length;
+
         private readonly Options _options;
         public bool IsEnabled
         {
@@ -47,6 +50,36 @@ namespace BouyomiPlugin
         {
             get { return _options.IsKillBouyomiChan; }
             set { _options.IsKillBouyomiChan = value; }
+        }
+
+        public bool IsVoiceTypeSpecfied
+        {
+            get { return _options.IsVoiceTypeSpecfied; }
+            set { _options.IsVoiceTypeSpecfied = value; }
+        }
+
+        public int VoiceTypeSelectedIndex
+        {
+            get { var index = _options.VoiceTypeIndex; return index >= VoiceTypeSapi5Offset ? (index - VoiceTypeSapi5Offset) + VoiceTypeLength : index; }
+            set { _options.VoiceTypeIndex = value < 0 ? 0 : value >= VoiceTypeLength ? VoiceTypeSapi5Offset + value - VoiceTypeLength : value; }
+        }
+
+        public int VoiceVolume
+        {
+            get { return _options.VoiceVolume; }
+            set { _options.VoiceVolume = value; }
+        }
+
+        public int VoiceSpeed
+        {
+            get { return _options.VoiceSpeed; }
+            set { _options.VoiceSpeed = value; }
+        }
+
+        public int VoiceTone
+        {
+            get { return _options.VoiceTone; }
+            set { _options.VoiceTone = value; }
         }
 
         #region YouTubeLive
@@ -574,6 +607,9 @@ namespace BouyomiPlugin
                         break;
                     case nameof(_options.IsReadComment):
                         RaisePropertyChanged(nameof(IsReadComment));
+                        break;
+                    case nameof(_options.IsVoiceTypeSpecfied):
+                        RaisePropertyChanged(nameof(IsVoiceTypeSpecfied));
                         break;
                 }
             };

--- a/BouyomiPlugin/Options.cs
+++ b/BouyomiPlugin/Options.cs
@@ -13,6 +13,11 @@ namespace BouyomiPlugin
         public string NickTitle { get { return GetValue(); } set { SetValue(value); } }
         public bool Want184Read { get { return GetValue(); } set { SetValue(value); } }
         public bool IsKillBouyomiChan { get { return GetValue(); } set { SetValue(value); } }
+        public bool IsVoiceTypeSpecfied { get { return GetValue(); } set { SetValue(value); } }
+        public int VoiceTypeIndex { get { return GetValue(); } set { SetValue(value); } }
+        public int VoiceVolume { get { return GetValue(); } set { SetValue(value); } }
+        public int VoiceSpeed { get { return GetValue(); } set { SetValue(value); } }
+        public int VoiceTone { get { return GetValue(); } set { SetValue(value); } }
 
         //YouTubeLive
         public bool IsYouTubeLiveConnect { get { return GetValue(); } set { SetValue(value); } }
@@ -92,6 +97,11 @@ namespace BouyomiPlugin
             Dict.Add(nameof(NickTitle), new Item { DefaultValue = "さん", Predicate = s => true, Serializer = s => s, Deserializer = s => s });
             Dict.Add(nameof(Want184Read), new Item { DefaultValue = true, Predicate = b => true, Serializer = b => b.ToString(), Deserializer = s => bool.Parse(s) });
             Dict.Add(nameof(IsKillBouyomiChan), new Item { DefaultValue = false, Predicate = b => true, Serializer = b => b.ToString(), Deserializer = s => bool.Parse(s) });
+            Dict.Add(nameof(IsVoiceTypeSpecfied), new Item { DefaultValue = false, Predicate = b => true, Serializer = b => b.ToString(), Deserializer = s => bool.Parse(s) });
+            Dict.Add(nameof(VoiceTypeIndex), new Item { DefaultValue = 0, Predicate = n => true, Serializer = n => n.ToString(), Deserializer = n => int.Parse(n) });
+            Dict.Add(nameof(VoiceVolume), new Item { DefaultValue = 100, Predicate = n => true, Serializer = n => n.ToString(), Deserializer = n => int.Parse(n) });
+            Dict.Add(nameof(VoiceSpeed), new Item { DefaultValue = 100, Predicate = n => true, Serializer = n => n.ToString(), Deserializer = n => int.Parse(n) });
+            Dict.Add(nameof(VoiceTone), new Item { DefaultValue = 100, Predicate = n => true, Serializer = n => n.ToString(), Deserializer = n => int.Parse(n) });
 
             //YouTubeLive
             Dict.Add(nameof(IsYouTubeLiveConnect), new Item { DefaultValue = false, Predicate = b => true, Serializer = b => b.ToString(), Deserializer = s => bool.Parse(s) });

--- a/BouyomiPlugin/main.cs
+++ b/BouyomiPlugin/main.cs
@@ -108,10 +108,10 @@ namespace BouyomiPlugin
 
                     if (_options.IsAppendNickTitle)
                         nick += _options.NickTitle;
-                    _bouyomiChanClient.AddTalkTask2(nick);
+                    TalkText(nick);
                 }
                 if (_options.IsReadComment)
-                    _bouyomiChanClient.AddTalkTask2(data.Comment);
+                    TalkText(data.Comment);
             }
             catch (System.Runtime.Remoting.RemotingException)
             {
@@ -534,7 +534,7 @@ namespace BouyomiPlugin
                     }
                     dataToRead += comment;
                 }
-                _bouyomiChanClient.AddTalkTask2(dataToRead);
+                TalkText(dataToRead);
             }
             catch (System.Runtime.Remoting.RemotingException)
             {
@@ -560,6 +560,25 @@ namespace BouyomiPlugin
 
             }
         }
+
+        private int TalkText(string text)
+        {
+            if (_options.IsVoiceTypeSpecfied)
+            {
+                return _bouyomiChanClient.AddTalkTask2(
+                    text,
+                    _options.VoiceSpeed,
+                    _options.VoiceTone,
+                    _options.VoiceVolume,
+                    (FNF.Utility.VoiceType)Enum.ToObject(typeof(FNF.Utility.VoiceType), _options.VoiceTypeIndex)
+                );
+            }
+            else
+            {
+                return _bouyomiChanClient.AddTalkTask2(text);
+            }
+        }
+
         public IPluginHost Host { get; set; }
         public string GetSettingsFilePath()
         {


### PR DESCRIPTION
- BouyomiPlugin に、読み上げ音声を指定できるように、設定項目を追加しました。

- 「読み上げ音声を指定する」をオンにすると、音声の各項目(声質, 音量, 速度, 音程)を指定できるようになります。

- オンにした場合は、`BouyomiChanClient.AddTalkTask2` の音声パラメーター指定版を呼び出します。

- デフォルト設定はオフで、この場合は以前と変わらず、`BouyomiChanClient.AddTalkTask2` のテキストパラメーターのみ版を呼び出します。
