### PR TITLE
稀にユーザ情報が取得できない場合があり取得出来ないとコメントすら表示されなくなるので回避

### DIFF
--- a/NicoSitePlugin2/Api.cs
+++ b/NicoSitePlugin2/Api.cs
@@ -30,9 +30,7 @@ namespace NicoSitePlugin
             var res = await server.GetAsync(url, cc);
             var obj = JsonConvert.DeserializeObject<NicoSitePlugin2.Low.UserInfo.RootObject>(res);
             if (obj.Data.Length == 0)
-            {
-                throw new ArgumentException("指定されたuserIdは存在しない:" + userId);
-            }
+                return null;
             var data = obj.Data[0];
             var userInfo = new UserInfo
             {

--- a/NicoSitePlugin2/TestCommentProvider.cs
+++ b/NicoSitePlugin2/TestCommentProvider.cs
@@ -417,16 +417,15 @@ namespace NicoSitePlugin
                             {
                                 _chatProvider?.Disconnect();
                             }
-                            string username;
+                            string username = null;
                             if (IsRawUserId(chat.UserId) && chat.UserId != SystemUserId && _siteOptions.IsAutoGetUsername)
                             {
                                 var userInfo = await Api.GetUserInfo(_server, _cc, chat.UserId);
-                                username = userInfo.Nickname;
-                                user.Name = Common.MessagePartFactory.CreateMessageItems(username);
-                            }
-                            else
-                            {
-                                username = null;
+                                if (userInfo != null)
+                                {
+                                    username = userInfo.Nickname;
+                                    user.Name = Common.MessagePartFactory.CreateMessageItems(username);
+                                }
                             }
                             if (_siteOptions.IsAutoSetNickname)
                             {

--- a/NicoSitePlugin2/TestCommentProvider.cs
+++ b/NicoSitePlugin2/TestCommentProvider.cs
@@ -421,11 +421,8 @@ namespace NicoSitePlugin
                             if (IsRawUserId(chat.UserId) && chat.UserId != SystemUserId && _siteOptions.IsAutoGetUsername)
                             {
                                 var userInfo = await Api.GetUserInfo(_server, _cc, chat.UserId);
-                                if (userInfo != null)
-                                {
-                                    username = userInfo.Nickname;
-                                    user.Name = Common.MessagePartFactory.CreateMessageItems(username);
-                                }
+                                username = userInfo?.Nickname;
+                                user.Name = Common.MessagePartFactory.CreateMessageItems(username);
                             }
                             if (_siteOptions.IsAutoSetNickname)
                             {


### PR DESCRIPTION
# 背景
稀にユーザ情報が取得出来ない時があり（サーバ側が不安定だったり、人により）、その場合コメントすら表示されなくなってしまう。
# 解決方法
ユーザ情報取得時にDataが0だった場合に例外としていたのをnullにし、nullじゃなければニックネームを使用するようにした
# 影響
無し。使用箇所はTestCommentProviderのみ。