### PR TITLE
ニコ生でユーザー名が表示されるよう修正

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,7 +10,7 @@
 # default for csharp files.
 # Note: This is only used by command line
 ###############################################################################
-#*.cs     diff=csharp
+*.cs     diff=csharp
 
 ###############################################################################
 # Set the merge driver for project and solution files

--- a/NicoSitePlugin2/Api.cs
+++ b/NicoSitePlugin2/Api.cs
@@ -16,12 +16,6 @@ namespace NicoSitePlugin
         }
     }
     class NotLoggedInException : Exception { }
-    class UserInfo
-    {
-        public string Nickname { get; set; }
-        public string UserIconUrl { get; set; }
-
-    }
     static class Api
     {
         public static async Task<CommunityLiveInfo[]> GetCommunityLives(IDataSource server, CookieContainer cc, string communityId)

--- a/NicoSitePlugin2/TestCommentProvider.cs
+++ b/NicoSitePlugin2/TestCommentProvider.cs
@@ -427,6 +427,9 @@ check:
                             {
                                 _chatProvider?.Disconnect();
                             }
+                            if (chat.Name != null) {
+                                user.Name = Common.MessagePartFactory.CreateMessageItems(chat.Name);
+                            }
                             if (_siteOptions.IsAutoSetNickname)
                             {
                                 var nick = SitePluginCommon.Utils.ExtractNickname(chat.Content);


### PR DESCRIPTION
#218

[このコミット](https://github.com/CommentViewerCollection/MultiCommentViewer/commit/e0a3b0c170178f3a7636b21eb17a27ad78c8233c#diff-b407c622b574591e02053dcb0db0402d03659c9fe1b02e339d38b1ddde7b6ee1)
以降user.Nameが設定されていなくなりユーザー名が表示されなくなっていたため修正しました
また、同コミット以降使用されていないクラスを削除しました